### PR TITLE
Refact/add multiple cryptos BREAKING CHANGE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,88 @@
-# Coinprice
+# Coinprice CLI 💰
 
-A simple CLI tool written in Go to get the current price of Bitcoin in **BRL** or **USD** using the CoinGecko API.
+A lightweight cryptocurrency price checker written in Go that supports multiple coins and currencies using the CoinGecko API.
 
-## 🛠 Installation
+## 🌟 Features
 
-Make sure you have Go installed (`go version`).
+- Get real-time prices for 30+ cryptocurrencies
+- Supports both BRL (Brazilian Real) and USD (US Dollar)
+- Simple JSON output option for integration with other tools
+- Fast and lightweight (single binary)
+
+## 📦 Installation
+
+### Using Go (development)
 
 ```bash
 go install github.com/aureliomalheiros/coinprice@latest
 ```
 
-### 📦 Example
+#### Pre-built binaries
+
+Download from the [Releases page](https://github.com/aureliomalheiros/coinprice/releases)
+
+### 🚀 Basic Usage
+
+- Get Bitcoin price (default)
+coinprice --brl       # Price in Brazilian Real
+coinprice --usd       # Price in US Dollar
+
+- Get specific cryptocurrency prices
+coinprice --coin ethereum --brl
+coinprice --coin solana --usd
+
+- Multiple currencies
+coinprice --brl --usd
+
+- JSON output
+coinprice --brl --json
+
+- Options
 
 ```bash
-coinprice -brl       # Get Bitcoin price in Brazilian Real
-coinprice -dollar    # Get Bitcoin price in US Dollar
+-b, --brl        Get price in Brazilian Real
+-u, --usd        Get price in US Dollar
+-c, --coin string Specify cryptocurrency (default "bitcoin")
+-j, --json       Output in JSON format
+-h, --help       Show help
 ```
+
+## Supported Cryptocurrencies 🪙
+
+| Coin Name          | ID (for --coin flag)  |
+|--------------------|-----------------------|
+| Bitcoin            | `bitcoin`            |
+| Ethereum           | `ethereum`           |
+| Aave               | `aave`               |
+| Solana             | `solana`             |
+| Dogecoin           | `dogecoin`           |
+| Litecoin           | `litecoin`           |
+| Ripple (XRP)       | `ripple`             |
+| Cardano            | `cardano`            |
+| Polkadot           | `polkadot`           |
+| Chainlink          | `chainlink`          |
+| Uniswap            | `uniswap`            |
+| Avalanche          | `avalanche`          |
+| Cosmos             | `cosmos`             |
+| Stellar            | `stellar`            |
+| Monero             | `monero`             |
+| Tron               | `tron`               |
+| Algorand           | `algorand`           |
+| VeChain            | `vechain`            |
+| Filecoin           | `filecoin`           |
+| Bitcoin Cash       | `bitcoin-cash`       |
+| Dash               | `dash`               |
+| Zcash              | `zcash`              |
+| Tezos              | `tezos`              |
+| Neo                | `neo`                |
+| Elrond             | `elrond`             |
+| Hedera             | `hedera`             |
+| Fantom             | `fantom`             |
+| Decentraland       | `decentraland`       |
+| The Sandbox        | `the-sandbox`        |
+| Axie Infinity      | `axie-infinity`      |
+| Chiliz             | `chiliz`             |
+| Enjin Coin         | `enjin-coin`         |
+| Theta              | `theta`              |
+
+> Note: All coin IDs are lowercase and use hyphens for multi-word names

--- a/internal/price/coingeckoBitcoin.go
+++ b/internal/price/coingeckoBitcoin.go
@@ -4,51 +4,56 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
+	
+	"github.com/aureliomalheiros/coinprice/internal/validates"
 )
 
-type coingeckoResponse struct {
-	Bitcoin struct {
-		BRL float64 `json:"brl"`
-		USD float64 `json:"usd"`
-	} `json:"bitcoin"`
+type CoinPrice struct {
+	BRL float64 `json:"brl"`
+	USD float64 `json:"usd"`
 }
 
-func GetBitcoinPriceBRL(currency string) (float64, error) {
+type CoinGeckoResponse map[string]CoinPrice
 
-	validCurrency := map[string]bool {
-		"brl": true,
-		"usd": true,
+func GetCryptoPrice(coin, currency string) (float64, error) {
+	if err := validates.ValidateInput(coin, currency); err != nil {
+		return 0, err
 	}
 
-	if !validCurrency[currency] {
-		return 0, fmt.Errorf("Invalid currency: %s. Valid options are: brl, usd", currency)
+	if coin == "" {
+		coin = "bitcoin"
 	}
 
-	url := fmt.Sprintf("https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=%s", currency)
+	client := &http.Client{Timeout: 10 * time.Second}
+	url := fmt.Sprintf("https://api.coingecko.com/api/v3/simple/price?ids=%s&vs_currencies=%s", coin, currency)
 
-	resp, err := http.Get(url)
-	if err != nil  {
-		return 0, fmt.Errorf("Error fetching data from CoinGecko: %w", err)
+	resp, err := client.Get(url)
+	if err != nil {
+		return 0, fmt.Errorf("error fetching data from CoinGecko: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return 0, fmt.Errorf("Error: received status code %d from CoinGecko", resp.StatusCode)
-	}
-	
-	var result coingeckoResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return 0, fmt.Errorf("Error decoded JSON: %w", err)
+		return 0, fmt.Errorf("error: received status code %d from CoinGecko", resp.StatusCode)
 	}
 
+	var result CoinGeckoResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return 0, fmt.Errorf("error decoding JSON: %w", err)
+	}
+
+	coinData, exists := result[coin]
+	if !exists {
+		return 0, fmt.Errorf("coin '%s' not found in response", coin)
+	}
 
 	switch currency {
-		case "brl":
-			return result.Bitcoin.BRL, nil
-		case "usd":
-			return result.Bitcoin.USD, nil
-		default:
-			return 0, fmt.Errorf("Unsupported currency: %s", currency)
+	case "brl":
+		return coinData.BRL, nil
+	case "usd":
+		return coinData.USD, nil
+	default:
+		return 0, fmt.Errorf("unsupported currency: %s", currency)
 	}
-
 }

--- a/internal/validates/validateInput.go
+++ b/internal/validates/validateInput.go
@@ -1,0 +1,66 @@
+package validates
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+func ValidateInput(coin, currency string) error {
+	validCurrencies := map[string]bool{
+		"brl": true,
+		"usd": true,
+	}
+	
+	validCoin := map[string]bool{
+		"bitcoin": true,
+		"ethereum": true,
+		"aave": true,
+		"solana": true,
+		"dogecoin": true,
+		"litecoin": true,
+		"ripple": true,
+		"cardano": true,
+		"polkadot": true,
+		"chainlink": true,
+		"uniswap": true,
+		"avalanche": true,
+		"cosmos": true,
+		"stellar": true,
+		"monero": true,
+		"tron": true,
+		"algorand": true,
+		"vechain": true,
+		"filecoin": true,
+		"bitcoin-cash": true,
+		"dash": true,
+		"zcash": true,
+		"tezos": true,
+		"neo": true,
+		"elrond": true,
+		"hedera": true,
+		"fantom": true,
+		"decentraland": true,
+		"the-sandbox": true,
+		"axie-infinity": true,
+		"chiliz": true,
+		"enjin-coin": true,
+		"theta": true,			
+	}
+
+	if !validCurrencies[currency] {
+		return fmt.Errorf("Invalid currency: %s. Valid options are: brl, usd", currency)
+	}
+
+	if !validCoin[coin] {
+		var coins []string
+		for c := range validCoin {
+			coins = append(coins, c)
+		}
+		sort.Strings(coins)
+
+		return fmt.Errorf("Invalid coin: %s. Available cryptocurrencies:\n%s", coin, strings.Join(coins, "\n"))
+	}
+
+	return nil
+}


### PR DESCRIPTION
refactor(BREAKING CHANGE): improve cryptocurrency validation and error messaging
    
    - Fix cryptocurrency validation in validates package
    - Enhance error messages to show available coin options
    - Add complete list of supported cryptocurrencies
    - Implement organized formatting for coin list
    - Add detailed help in main command
    
    Now when users input an invalid coin like "br", they'll see a properly formatted list of all available options.
    
    Example error message:

    ```bash
    invalid coin: br
    
    Available cryptocurrencies:
    aave
    algorand
    avalanche
    axie-infinity
    bitcoin
    bitcoin-cash
    ```